### PR TITLE
Fix exception on fs.mkdir

### DIFF
--- a/source/makedir.js
+++ b/source/makedir.js
@@ -25,7 +25,7 @@ function existTree(fullpath, callback) {
 function makedirTree(fullpath) {
   existTree(fullpath, (exists, dirpath) => {
     if (exists) return;
-    fs.mkdir(dirpath);
+    fs.mkdirSync(dirpath);
   });
 }
 


### PR DESCRIPTION
Changed to mkdirSync (synchronous version of the method) to avoid the exception: [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined.